### PR TITLE
eap-tests/cluster1: Add the /Delay servlet

### DIFF
--- a/eap-tests/cluster1/src/main/java/org/openshift/examples/cluster1/Delay.java
+++ b/eap-tests/cluster1/src/main/java/org/openshift/examples/cluster1/Delay.java
@@ -1,0 +1,48 @@
+package org.openshift.examples.cluster1;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class Delay extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        PrintWriter out = response.getWriter();
+
+        String d = request.getParameter("d");
+        if (d == null || d.isEmpty())
+            d = "180";
+        int seconds;
+        try {
+            seconds = Integer.parseInt(d);
+            if (seconds < 0)
+                seconds = 0;
+        } catch (NumberFormatException e) {
+            seconds = 180;
+        }
+
+        out.println(String.format("Delaying %d seconds from node: %s", seconds, InetAddress.getLocalHost().toString()));
+        out.flush();
+
+        for (int i = 0; i < seconds; i++) {
+            try {
+                out.println("*");
+                out.flush();
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        out.println("Bye");
+    }
+
+}

--- a/eap-tests/cluster1/src/main/webapp/WEB-INF/web.xml
+++ b/eap-tests/cluster1/src/main/webapp/WEB-INF/web.xml
@@ -20,6 +20,11 @@
   	<servlet-class>org.openshift.examples.cluster1.ShowHeaders</servlet-class>
   </servlet>
 
+  <servlet>
+    <servlet-name>Delay</servlet-name>
+    <servlet-class>org.openshift.examples.cluster1.Delay</servlet-class>
+  </servlet>
+
   <servlet-mapping>
   	<servlet-name>Hi</servlet-name>
   	<url-pattern>/Hi</url-pattern>
@@ -33,5 +38,10 @@
   <servlet-mapping>
   	<servlet-name>ShowHeaders</servlet-name>
   	<url-pattern>/ShowHeaders</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>
+    <servlet-name>Delay</servlet-name>
+    <url-pattern>/Delay</url-pattern>
   </servlet-mapping>
 </web-app>


### PR DESCRIPTION
Its job is to simulate a long request/response.

It handles GET requests and accepts an optional parameter
named "d" which stores the number of seconds the request
should long. It defaults to 180.