### PR TITLE
spring-boot-sample-simple: Add enforcer plugin

### DIFF
--- a/spring-boot-sample-simple/pom.xml
+++ b/spring-boot-sample-simple/pom.xml
@@ -36,6 +36,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>1.4.1</version>
+              <executions>
+                <execution>
+                  <id>enforce-property</id>
+                  <goals>
+                    <goal>enforce</goal>
+                  </goals>
+                  <configuration>
+                    <rules>
+                      <requireProperty>
+                        <property>com.redhat.xpaas.repo.redhatga</property>
+                        <message>You must set com.redhat.xpaas.repo.redhatga!</message>
+                      </requireProperty>
+                    </rules>
+                    <fail>true</fail>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Enforce the definition of the property com.redhat.xpaas.repo.redhatag.

This is to aid tests to ensure that the redhatga repo is enabled. We
aren't testing exactly that -- the repo is enabled by the property in
most quickstarts, and this tests the property, not the repo - but it's
close.