### PR TITLE
update redhat-sso image version

### DIFF
--- a/demos/sso/sso70-eap64-all-in-one-demo.json
+++ b/demos/sso/sso70-eap64-all-in-one-demo.json
@@ -520,7 +520,7 @@
                              "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "redhat-sso70-openshift:1.3"
+                                "name": "redhat-sso70-openshift:1.4"
                             }
                         }
                     },

--- a/demos/sso/sso70-eap70-all-in-one-demo.json
+++ b/demos/sso/sso70-eap70-all-in-one-demo.json
@@ -520,7 +520,7 @@
                              "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "redhat-sso70-openshift:1.3"
+                                "name": "redhat-sso70-openshift:1.4"
                             }
                         }
                     },

--- a/demos/sso/sso71-eap64-all-in-one-demo.json
+++ b/demos/sso/sso71-eap64-all-in-one-demo.json
@@ -520,7 +520,7 @@
                              "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "redhat-sso71-openshift:1.0"
+                                "name": "redhat-sso71-openshift:1.1"
                             }
                         }
                     },

--- a/demos/sso/sso71-eap70-all-in-one-demo.json
+++ b/demos/sso/sso71-eap70-all-in-one-demo.json
@@ -520,7 +520,7 @@
                              "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "redhat-sso71-openshift:1.0"
+                                "name": "redhat-sso71-openshift:1.1"
                             }
                         }
                     },


### PR DESCRIPTION
The previous image version (1.3) is not resovable from public registry.
The latest one is 1.4 for sso70 and 1.1 for sso71