### PR TITLE
[KEYCLOAK-7630] Add example on how to override the default version of the RH-SSO adapters installed in the EAP 6.4 / 7.1 for OpenShift images

### DIFF
--- a/eap-s2i-install-custom-rh-sso-adapters/README.md
+++ b/eap-s2i-install-custom-rh-sso-adapters/README.md
@@ -1,0 +1,276 @@
+# Example on how to install custom RH-SSO adapters to EAP 6.4 or EAP 7.1 Middleware images
+
+## About
+This example shows how to install custom RH-SSO adapters to EAP 6.4 or EAP 7.1 Middleware images. The adapters to be installed are expected to be specified as the value of *_SSO_ADAPTERS_OVERRIDES_* environment variable, which can have one of the following three values:
+
+* **latest** or **LATEST**
+
+	In this case, the latest available version of RH-SSO SAML and Wildfly adapters will be installed,
+
+* **3.4.3.Final-redhat-2**
+
+	In this case, the specified *_3.4.3.Final-redhat-2_* version of RH-SSO SAML and Wildfly adapters will be installed, or
+
+* **https://maven.repository.redhat.com/ga/org/keycloak/keycloak-wildfly-adapter-dist/3.4.8.Final-redhat-6/keycloak-wildfly-adapter-dist-3.4.8.Final-redhat-6.zip,https://maven.repository.redhat.com/ga/org/keycloak/keycloak-saml-wildfly-adapter-dist/3.4.8.Final-redhat-6/keycloak-saml-wildfly-adapter-dist-3.4.8.Final-redhat-6.zip**
+
+	In this case the RH-SSO SAML and Wildfly adapters from particular Zip archives, specified as a comma-separated list of URLs will be retrieved and installed.
+
+**Important: The versions of both the SAML and Wildfly RH-SSO adapters to be installed need to match!!!**
+
+## How it works
+
+The example [overrides the default form of the *_assemble_* S2I script](https://docs.openshift.com/container-platform/3.3/dev_guide/builds.html#override-builder-image-scripts), as provided by the EAP 6.4 or EAP 7.1 Middleware images to define new [*_install_custom_rh_sso_adapters()_*](https://github.com/iankko/openshift-examples/blob/eap-s2i-custom-rh-sso-adapters/eap-s2i-install-custom-rh-sso-adapters/s2i/assemble#L213) routine, which is retrieving the specified RH-SSO adapters, and installing them.
+
+## How to use
+
+### Prerequisite:
+
+Perform the following steps to utilize this change:
+
+* Deploy [RH-SSO for OpenShift image](https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html-single/red_hat_single_sign-on_for_openshift/#requirements_and_deploying_link_xl_href_introduction_introduction_xml_passthrough_templates_passthrough_tls_termination_link_rh_sso_templates). These steps will produce RH-SSO server pod running in the *_sso-app-demo_* OpenShift namespace/project.
+
+### Using the change one-time way (against specific buildConfig):
+
+To use the custom *_assemble_* S2I builder image script one-time way (only against the specific buildConfig) perform the following steps:
+
+* Deploy [an application on top of EAP 6.4 or EAP 7.1 Middleware images, secured against the RH-SSO server](https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html-single/red_hat_single_sign-on_for_openshift/#deploy_binary_build_of_eap_6_4_7_0_jsp_service_invocation_application_and_secure_it_using_red_hat_single_sign_on) created in previous step. These steps will produce the application pod running in the *_eap-app-demo_* OpenShift namespace/project.
+* In the *_eap-app-demo_* namespace edit the buildConfig definition to define desired form of the *_SSO_ADAPTERS_OVERRIDES_* environment variable:
+
+  * Determine the name of the buildConfig in question:
+    ```
+    $ oc get bc -o name
+    buildconfigs/eap-app
+    ```
+  * Patch the definition by supplying custom location of the S2I build scripts to use
+    ```
+    $ oc patch bc/eap-app --type=json \
+    -p '[{"op": "add", "path": "/spec/strategy/sourceStrategy/scripts", "value": "https://raw.githubusercontent.com/iankko/openshift-examples/eap-s2i-custom-rh-sso-adapters/eap-s2i-install-custom-rh-sso-adapters/s2i"}]'
+    ```
+  * Define the *_SSO_ADAPTERS_OVERRIDES_* variable with expected value:
+    ```
+    $ oc set env bc/eap-app -e SSO_ADAPTERS_OVERRIDES="3.4.3.Final-redhat-2"
+    ```
+  * (Optional) Verify the *_SSO_ADAPTERS_OVERRIDES_* definition:
+    ```
+    $ oc env bc/eap-app --list
+    ```
+  * Start new build and wait for the build to finish:
+    ```
+    $ oc start-build bc/eap-app --follow
+    ```
+  * Deploy the application from the latest build:
+    ```
+    $ oc rollout latest dc/eap-app
+    ```
+  * Verify the version of the RH-SSO adapters installed in the pod:
+    ```
+    $ oc rsh eap-app-56-gzm4g find / -name *.jar 2>/dev/null | grep keycloak | head -2
+    /opt/eap/modules/system/add-ons/keycloak/org/keycloak/keycloak-common/main/keycloak-common-3.4.3.Final-redhat-2.jar
+    /opt/eap/modules/system/add-ons/keycloak/org/keycloak/keycloak-adapter-spi/main/keycloak-undertow-adapter-spi-3.4.3.Final-redhat-2.jar
+    ```
+
+### Modifying the default form of *_eap64-sso-s2i_* and *_eap71-sso-s2i_* application templates
+
+Alternatively, it is possible directly to modify the default definition of the *_eap64-sso-s2i_* and *_eap71-sso-s2i_* application templates to achieve the override RH-SSO adapters functionality to be available for each deployment provisioned from now on from these two templates. If this is desired, perform the following steps:
+
+#### Create new namespace. Grant view role to the default service account
+
+  * Create a new *_eap-app-adapters-install-demo_* namespace:
+    ```
+    $ oc new-project eap-app-adapters-install-demo
+    ```
+  * Grant the *_view_* role to the *_default_* service account:
+    ```
+    $ oc policy add-role-to-user view system:serviceaccount:$(oc project -q):default
+    ```
+
+#### Generate SSL and JGroups keystore for the EAP template
+
+  * The EAP template requires an [SSL keystore and a JGroups keystore](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html-single/red_hat_jboss_sso_for_openshift/#Configuring-Keystores). his example uses **keytool**, a package included with the Java Development Kit, to generate self-signed certificates for these keystores.
+
+    * Generate a secure key for the SSL keystore (this example uses **password** as password for the keystore).
+      ```
+      $ keytool -genkeypair \
+      -dname "CN=secure-eap-app-eap-app-adapters-install-demo.openshift.example.com" \
+      -alias https \
+      -storetype JKS \
+      -keystore eapkeystore.jks
+      ```
+    * Generate a secure key for the JGroups keystore (this example uses **password** as password for the keystore).
+      ```
+      $ keytool -genseckey \
+      -alias jgroups \
+      -storetype JCEKS \
+      -keystore eapjgroups.jceks
+      ```
+    * Generate the EAP 6.4 / 7.0 for OpenShift secrets with the SSL and JGroup keystore files.
+      ```
+      $ oc create secret generic eap-ssl-secret --from-file=eapkeystore.jks
+      ```
+
+      ```
+      $ oc create secret generic eap-jgroup-secret --from-file=eapjgroups.jceks
+      ```
+    * Add the EAP application secret to the [default](https://docs.openshift.com/container-platform/latest/dev_guide/service_accounts.html#default-service-accounts-and-roles) service account.
+      ```
+      $ oc secrets link default eap-ssl-secret eap-jgroup-secret
+      ```
+
+#### Create modified *_eap71-sso-s2i-adapters-install_* application template
+
+  **Important**: To be able to import the modified *_eap71-sso-s2i-adapters-install_* application template into the *_openshift_* namespace below, the user account in question needs to have cluster administrator privileges or the user needs to have project administrator access to the global *_openshift_* project. On your master host(s), login as follows:
+  ```
+  $ oc login -u system:admin
+  ```
+
+  * Export the original form of the *_eap71-sso-s2i_* application template:
+    ```
+    $ oc export template/eap71-sso-s2i -n openshift -o json > /tmp/eap71-sso-s2i-adapters-install.json
+    ```
+  * Modify its name to *_eap71-sso-s2i-adapters-install_* so it does not collide with the original when imported back in the next step:
+    ```
+    $ sed -i 's/eap71-sso-s2i/eap71-sso-s2i-adapters-install/g' /tmp/eap71-sso-s2i-adapters-install.json
+    ```
+  * Import the customized *_eap71-sso-s2i-adapters-install_* template back to the *_openshift_* namespace:
+    ```
+    $ oc create -f /tmp/eap71-sso-s2i-adapters-install.json -n openshift
+    ```
+  * Define the *_strategy/sourceStrategy/scripts_* field of the template to point to custom location of the S2I image builder scripts:
+    ```
+    oc patch template/eap71-sso-s2i-adapters-install -n openshift --type=json \
+    -p '[{"op": "add", "path": "/objects/6/spec/strategy/sourceStrategy/scripts", "value": "https://raw.githubusercontent.com/iankko/openshift-examples/eap-s2i-custom-rh-sso-adapters/eap-s2i-install-custom-rh-sso-adapters/s2i"}]'
+    ``` 
+   **Note:** The BuildConfig is defined as the 7-th element of the *_objects_* array in the template. That's the reason we use *_6_* index to reference it in the previous command (indexing starts from zero).
+
+  * Edit the template to require the new *_SSO_ADAPTERS_OVERRIDES_* environment variable, defaulting to the **latest** value. Append this variable as the last one into the existing list of template parameters:
+    ```
+    $ oc patch template/eap71-sso-s2i-adapters-install -n openshift --type=json \
+    -p '[{"op": "add", "path": "/parameters/-", "value": {"name": "SSO_ADAPTERS_OVERRIDES", "displayName": "RH-SSO adapters overrides", "description": "Override the default version of the installed RH-SSO adapters", "value": "latest", "required": true}}]'
+    ```
+  * Pass the provided value of the *_SSO_ADAPTERS_OVERRIDES_* parameter (user input) to the particular buildConfig:
+    ```
+    $ oc patch template/eap71-sso-s2i-adapters-install -n openshift --type=json \
+    -p '[{"op": "add", "path": "/objects/6/spec/strategy/sourceStrategy/env/-", "value": {"name": "SSO_ADAPTERS_OVERRIDES", "value": "${SSO_ADAPTERS_OVERRIDES}"}}]'
+    ```
+
+#### Deploy the application using the modified *_eap71-sso-s2i-adapters-install_* template
+
+  * Finally, deploy the application from the modified *_eap71-sso-s2i-adapters-install_* template, using the *_3.4.6.Final-redhat-1_* as the version of the RH-SSO adapters:
+
+   **Important: Be sure to modify the values of the *_SSO_REALM_*, *_SSO_USERNAME_*, *_SSO_PASSWORD_*, and *_SSO_PUBLIC_KEY_* variables in the following command, as appropriate for your environment.**
+
+   **Note:** For simplicity, the following command uses the same secret to configure all of the following:
+    * HTTPS service,
+    * RH-SSO SAML client, and
+    * RH-SSO truststore.
+
+   **In production environment it is recommended to use different secrets per each of these aspects.** (in other words different secret for HTTPS service configuration, another one for RH-SSO SAML client configuration etc.).
+
+  ```
+  $ oc new-app --template=eap71-sso-s2i-adapters-install \
+  -p SSO_ADAPTERS_OVERRIDES="3.4.6.Final-redhat-1" \
+  -p HOSTNAME_HTTP="eap-app-eap-app-adapters-install-demo.openshift.example.com" \
+  -p HOSTNAME_HTTPS="secure-eap-app-eap-app-adapters-install-demo.openshift.example.com" \
+  -p SSO_URL="https://secure-sso-sso-app-demo.openshift.example.com/auth" \
+  -p SSO_SERVICE_URL="https://secure-sso.sso-app-demo.svc:8443/auth" \
+  -p SSO_REALM="demorealm" \
+  -p SSO_USERNAME="demouser" \
+  -p SSO_PASSWORD="demopassword" \
+  -p SSO_PUBLIC_KEY="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4zWb+NSohaR5vz7MAydmvV3tRE3NTnLYUeVITZ9BimCtvZJcP8HkUPfs9MjYr7/KnTTxRyMSAkgmUO4L4CBG88TNbEOuhKpJmXCvxW0wQfNRUG+5M4WMJ3McezhKqoxVRDF+iQ33I5hwbL1nnhKEL6TDuSPRA6/gOFVECMcG9/yydTe+mKlrhe5tBIX9EXe2u1tdy4VZVgj5QEmSWmADJj/EXWKYlE1WuTKIeYMXilHKAsMtVhfDKOedSZPnWUyFB2C2jXbOIK5Gohj/SqVcXCsHPO5cAMGJASL+x0/dIx4ZEMpbHiqs2Y3xazH3VmWnKowU0BKHKicMkUogCMMEoQIDAQAB" \
+  -p HTTPS_SECRET="eap-ssl-secret" \
+  -p HTTPS_KEYSTORE="eapkeystore.jks" \
+  -p HTTPS_NAME="https" \
+  -p HTTPS_PASSWORD="password" \
+  -p JGROUPS_ENCRYPT_SECRET="eap-jgroup-secret" \
+  -p JGROUPS_ENCRYPT_KEYSTORE="eapjgroups.jceks" \
+  -p JGROUPS_ENCRYPT_NAME="jgroups" \
+  -p JGROUPS_ENCRYPT_PASSWORD="password" \
+  -p SSO_SAML_KEYSTORE_SECRET="eap-ssl-secret" \
+  -p SSO_SAML_KEYSTORE="eapkeystore.jks" \
+  -p SSO_SAML_CERTIFICATE_NAME="https" \
+  -p SSO_SAML_KEYSTORE_PASSWORD="password" \
+  -p SSO_TRUSTSTORE_SECRET="eap-ssl-secret" \
+  -p SSO_TRUSTSTORE="eapkeystore.jks" \
+  -p SSO_TRUSTSTORE_PASSWORD="password"
+  ```
+
+  * Identify the build and wait for it to finish:
+    ```
+    $ oc get pods
+    NAME              READY     STATUS    RESTARTS   AGE
+    eap-app-1-build   1/1       Running   0          9s
+    ```
+
+    ```
+    $ oc logs eap-app-1-build --follow
+    ...
+    Pushing image docker-registry.default.svc:5000/eap-app-adapters-install-demo/eap-app:latest ...
+    Pushed 4/7 layers, 57% complete
+    Pushed 5/7 layers, 87% complete
+    Pushed 6/7 layers, 97% complete
+    Pushed 7/7 layers, 100% complete
+    Push successful
+    ```
+  *  Determine the name of the EAP application pod:
+    ```
+    $ oc get pods
+    NAME               READY     STATUS      RESTARTS   AGE
+    eap-app-1-56lh6    0/1       Running     0          16s
+    eap-app-1-build    0/1       Completed   0          9m
+    eap-app-1-deploy   1/1       Running     0          17s
+    ``` 
+  * Verify the version of the RH-SSO adapters installed in the pod:
+    ```
+    $ oc rsh eap-app-1-56lh6 find / -name *.jar 2>/dev/null | grep keycloak | tail -4
+    /opt/eap/modules/system/add-ons/keycloak/org/keycloak/keycloak-undertow-adapter/main/keycloak-undertow-adapter-3.4.6.Final-redhat-1.jar
+    /opt/eap/modules/system/add-ons/keycloak/org/keycloak/keycloak-wildfly-subsystem/main/keycloak-wildfly-subsystem-3.4.6.Final-redhat-1.jar
+    /opt/eap/modules/system/add-ons/keycloak/org/keycloak/keycloak-adapter-core/main/keycloak-adapter-core-3.4.6.Final-redhat-1.jar
+    /opt/eap/modules/system/add-ons/keycloak/org/keycloak/keycloak-core/main/keycloak-core-3.4.6.Final-redhat-1.jar
+    ```
+  * (Optionally) Verify the clients have been properly registered:
+    ```
+    $ oc logs eap-app-1-56lh6 | grep -P 'Registered .* client'
+    INFO Registered openid-connect client for module app-jsp in realm demorealm on "http://eap-app-eap-app-adapters-install-demo.openshift.example.com/app-jsp/*","https://secure-eap-app-eap-app-adapters-install-demo.openshift.example.com/app-jsp/*"
+    INFO Registered openid-connect client for module app-profile-jsp in realm demorealm on "http://eap-app-eap-app-adapters-install-demo.openshift.example.com/app-profile-jsp/*","https://secure-eap-app-eap-app-adapters-install-demo.openshift.example.com/app-profile-jsp/*"
+    INFO Registered openid-connect client for module service in realm demorealm on "http://eap-app-eap-app-adapters-install-demo.openshift.example.com/service/*","https://secure-eap-app-eap-app-adapters-install-demo.openshift.example.com/service/*"
+    INFO Registered saml client for module app-profile-saml in realm demorealm on "http://eap-app-eap-app-adapters-install-demo.openshift.example.com/app-profile-saml/*","https://secure-eap-app-eap-app-adapters-install-demo.openshift.example.com/app-profile-saml/*"
+    ``` 
+
+## What are the changes
+
+**Note:** Per suggestion in the [Overriding Builder Image Scripts](https://docs.openshift.com/container-platform/3.3/dev_guide/builds.html#override-builder-image-scripts) section of the OpenShift documentation the scripts path specified in the *_strategy/sourceStrategy/scripts_* field:
+
+> will have run, assemble, and save-artifacts appended to it. If any or all scripts are found they will be used in place of the same named script(s) provided in the image.
+
+Since the default form of [*_assemble_*](https://github.com/jboss-openshift/cct_module/blob/master/os-eap-s2i/added/s2i/assemble) S2I script, as shipped with the EAP 6.4 and EAP 7.1 Middleware images also imports:
+
+* [The code from *_common.sh_* shell script](https://github.com/jboss-openshift/cct_module/blob/master/os-eap-s2i/added/s2i/assemble#L8), and
+* [The code from *_scl-enable-maven_* script](https://github.com/jboss-openshift/cct_module/blob/master/os-eap-s2i/added/s2i/assemble#L9)
+
+the definition of the *_assemble.orig_* file, present in this repository has been modified with the expanded (full) form of these two scripts taken from the respective definitions of:
+* [*_common.sh_*](https://github.com/jboss-openshift/cct_module/blob/master/s2i-common/common.sh)
+* [*_scl-enable-maven_*](https://github.com/jboss-openshift/cct_module/blob/master/jboss-maven/added/s2i/scl-enable-maven)
+
+via the following two commands:
+
+ ```
+ $ sed -i \
+ -e '/. \$(dirname \$0)\/common.sh/r common.sh' \
+ -e '/. \$(dirname \$0)\/common.sh/d' assemble.orig
+ ```
+
+ ```
+ $ sed -i \
+ -e '/source \/usr\/local\/s2i\/scl-enable-maven/r scl-enable-maven' \
+ -e '/source \/usr\/local\/s2i\/scl-enable-maven/d' assemble.orig
+ ```
+
+**Without these changes**, the *_assemble_* script appended to the *_scripts_* path during processing of builder image scripts reported *_No such file or directory: common.sh_* error message.
+
+Clone the repository, and issue:
+
+```
+$ diff assemble.orig assemble
+```
+
+to see the actual implementation of the *_install_custom_rh_sso_adapters()_* routine and call to it (the changes between modified *_assemble_* script and its expanded form in the *_assemble.orig_* script).

--- a/eap-s2i-install-custom-rh-sso-adapters/s2i/assemble
+++ b/eap-s2i-install-custom-rh-sso-adapters/s2i/assemble
@@ -1,0 +1,414 @@
+#!/bin/bash
+
+BLACK='\033[0;30m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+DEFAULT='\033[0m'
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+fi
+
+function log_warning() {
+  local message="${1}"
+
+  echo >&2 -e "${YELLOW}WARN ${message}${DEFAULT}"
+}
+
+function log_error() {
+  local message="${1}"
+
+  echo >&2 -e "${RED}ERROR ${message}${DEFAULT}"
+}
+
+function log_info() {
+  local message="${1}"
+
+  echo >&2 -e "INFO ${message}"
+}
+
+# common shell routines for s2i scripts
+
+# insert settings for HTTP proxy into settings.xml if supplied as
+# separate variables HTTP_PROXY_HOST, _PORT, _SCHEME, _USERNAME,
+# _PASSWORD, _NONPROXYHOSTS
+function configure_proxy_write() {
+  local settings="${1:-$HOME/.m2/settings.xml}"
+  if [ -n "$HTTP_PROXY_HOST" -a -n "$HTTP_PROXY_PORT" ]; then
+    xml="<proxy>\
+         <id>genproxy</id>\
+         <active>true</active>\
+         <protocol>${HTTP_PROXY_SCHEME:-http}</protocol>\
+         <host>$HTTP_PROXY_HOST</host>\
+         <port>$HTTP_PROXY_PORT</port>"
+    if [ -n "$HTTP_PROXY_USERNAME" -a -n "$HTTP_PROXY_PASSWORD" ]; then
+      xml="$xml\
+         <username>$HTTP_PROXY_USERNAME</username>\
+         <password>$HTTP_PROXY_PASSWORD</password>"
+    fi
+    if [ -n "$HTTP_PROXY_NONPROXYHOSTS" ]; then
+      xml="$xml\
+         <nonProxyHosts>$HTTP_PROXY_NONPROXYHOSTS</nonProxyHosts>"
+    fi
+  xml="$xml\
+       </proxy>"
+    local sub="<!-- ### configured http proxy ### -->"
+    sed -i "s^${sub}^${xml}^" "$settings"
+  fi
+}
+
+# break a supplied url (as would be in HTTP_PROXY) up into constituent bits and
+# export the bits as variables that match our old scheme for configuring proxies
+# $settings - file to edit
+function configure_proxy_url() {
+  local url="$1"
+  local default_scheme="$2"
+  local default_port="$3"
+  if [ -n "$url" ] ; then
+    #[scheme://][user[:password]@]host[:port][/path][?params]
+    eval $(echo "$1" | sed -e "s+^\(\([^:]*\)://\)\?\(\([^:@]*\)\(:\([^@]*\)\)\?@\)\?\([^:/?]*\)\(:\([^/?]*\)\)\?.*$+HTTP_PROXY_SCHEME='\2' HTTP_PROXY_USERNAME='\4' HTTP_PROXY_PASSWORD='\6' HTTP_PROXY_HOST='\7' HTTP_PROXY_PORT='\9'+")
+
+    HTTP_PROXY_SCHEME="${HTTP_PROXY_SCHEME:-$default_scheme}"
+    HTTP_PROXY_PORT="${HTTP_PROXY_PORT:-$default_port}"
+
+    local noProxy="${no_proxy:-${NO_PROXY}}"
+    if [ -n "$noProxy" ]; then
+        noProxy="${noProxy//,/|}"
+        noProxy="${noProxy//|./|*.}"
+        noProxy="${noProxy/#./*.}"
+        HTTP_PROXY_NONPROXYHOSTS="${noProxy}"
+    fi
+  fi
+}
+
+function configure_proxy() {
+  local httpsProxy="${https_proxy:-${HTTPS_PROXY}}"
+  local httpProxy="${http_proxy:-${HTTP_PROXY}}"
+  local settings="$1"
+
+  if [ -n "${httpsProxy}" ] ; then
+    configure_proxy_url "${httpsProxy}" https 443
+  else
+    if [ -n "${httpProxy}" ] ; then
+      configure_proxy_url "${httpProxy}" http 80
+    fi
+  fi
+  configure_proxy_write "${settings}"
+}
+
+function find_env() {
+  local var=${!1}
+  echo "${var:-$2}"
+}
+
+# insert settings for mirrors/repository managers into settings.xml if supplied
+function configure_mirrors() {
+  local settings="${1-$HOME/.m2/settings.xml}"
+  local counter=1
+
+  # Be backwards compatible
+  if [ -n "${MAVEN_MIRROR_URL}" ]; then
+    local mirror_id=$(find_env "MAVEN_MIRROR_ID" "mirror.default")
+    local mirror_of=$(find_env "MAVEN_MIRROR_OF" "external:*")
+
+    configure_mirror "${settings}" "${mirror_id}" "${MAVEN_MIRROR_URL}" "${mirror_of}"
+  fi
+
+  IFS=',' read -a maven_mirror_prefixes <<< ${MAVEN_MIRRORS}
+  for maven_mirror_prefix in ${maven_mirror_prefixes[@]}; do
+    local mirror_id=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_ID" "mirror${counter}")
+    local mirror_url=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_URL")
+    local mirror_of=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_OF" "external:*")
+
+    if [ -z "${mirror_url}" ]; then
+      echo "WARNING: Variable \"${maven_mirror_prefix}_MAVEN_MIRROR_URL\" not set. Skipping maven mirror setup for the prefix \"${maven_mirror_prefix}\"."
+    else
+      configure_mirror "${settings}" "${mirror_id}" "${mirror_url}" "${mirror_of}"
+    fi
+
+    counter=$((counter+1))
+  done
+}
+
+function configure_mirror() {
+  local settings="${1}"
+  local mirror_id="${2}"
+  local mirror_url="${3}"
+  local mirror_of="${4}"
+
+  local xml="<mirror>\n\
+      <id>${mirror_id}</id>\n\
+      <url>${mirror_url}</url>\n\
+      <mirrorOf>${mirror_of}</mirrorOf>\n\
+    </mirror>\n\
+    <!-- ### configured mirrors ### -->"
+
+  sed -i "s|<!-- ### configured mirrors ### -->|$xml|" "${settings}"
+
+}
+
+# copy all artifacts of types, specified as the second up to n-th
+# argument of the routine into the $DEPLOY_DIR directory
+# Requires: source directory expressed in the form of absolute path!
+function copy_artifacts() {
+  dir=$1
+  types=
+  shift
+  while [ $# -gt 0 ]; do
+    types="$types;$1"
+    shift
+  done
+  
+  for d in $(echo $dir | tr "," "\n")
+  do
+    shift
+    local regex="^\/"
+    if [[ ! "$d" =~ $regex ]]; then
+      echo "$FUNCNAME: Absolute path required for source directory \"$d\"!"
+      exit 1
+    fi
+    for t in $(echo $types | tr ";" "\n")
+    do
+      echo "Copying all $t artifacts from $d directory into $DEPLOY_DIR for later deployment..."
+      cp -rfv $d/*.$t $DEPLOY_DIR 2> /dev/null
+    done
+  done
+}
+
+# handle incremental builds. If we have been passed build artifacts, untar
+# them over the supplied source.
+manage_incremental_build() {
+    if [ -d /tmp/artifacts ]; then
+        echo "Expanding artifacts from incremental build..."
+        ( cd /tmp/artifacts && tar cf - . ) | ( cd ${HOME} && tar xvf - )
+        rm -rf /tmp/artifacts
+    fi
+}
+
+# s2i 'save-artifacts' routine
+s2i_save_build_artifacts() {
+    cd ${HOME}
+    tar cf - .m2
+}
+
+# optionally clear the local maven repository after the build
+clear_maven_repository() {
+    mcr=$(echo "${MAVEN_CLEAR_REPO}" | tr [:upper:] [:lower:])
+    if [ "${mcr}" = "true" ]; then
+        rm -rf ${HOME}/.m2/repository/*
+    fi
+}
+
+# set local repository path for maven to the provided path
+function set_local_repo_path() {
+    local settings="${1}"
+    local local_path="${2}"
+    local xml="\n\
+    <localRepository>${local_path}</localRepository>"
+    sed -i "s|<!-- ### configured local repository ### -->|${xml}|" "${settings}"
+}
+
+# Install custom RH-SSO adapters specified as override argument
+function install_custom_rh_sso_adapters() {
+    local override_arg="${1}"
+    local adapter_version=""
+    local eap_launch_script="/opt/eap/bin/openshift-launch.sh"
+    # Code line of EAP launch script to insert overrides before
+    local eap_ls_anchor='if \[ "${SPLIT_DATA^^}" = "TRUE" \]; then'
+    local override_dir="/tmp/overridden_adapters"
+    # Remove the default version of the RH-SSO adapters
+    local override_stmnt="\\\n# Remove the default version of the RH-SSO adapters\n"
+    override_stmnt+="rm -rf /opt/eap/modules/system/add-ons/keycloak\n"
+    override_stmnt+="# Expand the custom version of the RH-SSO adapters\n"
+    # Array to hold the final depending on version generated URLs to RH-SSO adapters
+    local -a adapter_urls
+    local redhat_ga_maven_repo="https://maven.repository.redhat.com/ga"
+    local saml_dist_adapter="keycloak-saml-wildfly-adapter-dist"
+    local wildfly_dist_adapter="keycloak-wildfly-adapter-dist"
+    local latest_pattern="^(latest|LATEST)$"
+    local version_pattern="^([0-9].){3}Final-redhat-[0-9]$"
+    local url_pattern="^(http(|s)://.*\.zip,)+http(|s)://.*\.zip$"
+    if [[ "${override_arg}" =~ $latest_pattern ]]; then
+        adapter_version=$(curl -s ${redhat_ga_maven_repo}/org/keycloak/${saml_dist_adapter}/maven-metadata.xml | sed -nr 's/.*<latest>(([0-9]\.){3}Final-redhat-[0-9]).*/\1/p')
+    elif [[ "${override_arg}" =~ $version_pattern ]]; then
+        adapter_version="${override_arg}"
+    fi
+    if [[ "${override_arg}" =~ $url_pattern ]]; then
+        IFS=$',' read -a adapter_urls <<< "${override_arg}"
+    elif [ -n "${adapter_version}" ]; then
+        adapter_urls+=("${redhat_ga_maven_repo}/org/keycloak/${saml_dist_adapter}/${adapter_version}/${saml_dist_adapter}-${adapter_version}.zip")
+        adapter_urls+=("${redhat_ga_maven_repo}/org/keycloak/${wildfly_dist_adapter}/${adapter_version}/${wildfly_dist_adapter}-${adapter_version}.zip")
+    fi
+    if [ -n "${adapter_version}" ]; then
+        log_info "Going to install the \"${adapter_version}\" version of RH-SSO adapters."
+    else
+        if [ -n "${adapter_urls}" ]; then
+            log_info "Going to install the following ZIP archives:"
+            for url in "${adapter_urls[@]}"
+            do
+                log_info "${url}"
+            done
+        else
+            log_error "Unable to retrieve some of the specified \"${override_arg}\" archives."
+            exit 1
+        fi
+    fi
+    # Create directory to hold the ZIP archives with updated RH-SSO adapters
+    mkdir -p "${override_dir}"
+    # Obtain the archives
+    for adapter_url in "${adapter_urls[@]}"
+    do
+        cd "${override_dir}"
+        local adapter_archive=$(basename "${adapter_url}")
+        curl -sO "${adapter_url}"
+        if [ "$?" -eq "0" ]; then
+            log_info "Successfully retrieved the ${adapter_archive} archive."
+            override_stmnt+="unzip -qo ${override_dir}/${adapter_archive} -d \${JBOSS_HOME}\n"
+        else
+            log_warning "Failed to retrieve the ${adapter_archive} archive!"
+            exit 1
+        fi
+        cd - >/dev/null
+    done
+
+    # Enhance the EAP launch script
+    sed -i "/${eap_ls_anchor}/i ${override_stmnt}\n" "${eap_launch_script}"
+}
+
+source /opt/rh/rh-maven35/enable
+
+LOCAL_SOURCE_DIR=/tmp/src
+
+# Resulting WAR files will be deployed to /opt/eap/standalone/deployments
+DEPLOY_DIR=$JBOSS_HOME/standalone/deployments
+
+# JBoss AS data dir. Can be overridden.
+DATA_DIR=${DATA_DIR:-$JBOSS_HOME/standalone/data}
+
+# App data dir. Can be overridden.
+APP_DATADIR=${APP_DATADIR:-data}
+
+# the subdirectory within LOCAL_SOURCE_DIR from where we should copy build
+# artifacts (*.war, *.jar)
+ARTIFACT_DIR=${ARTIFACT_DIR:-target}
+
+if [ -f $LOCAL_SOURCE_DIR/configuration/settings.xml ]; then
+  echo "Copying maven config file from project..."
+  mkdir -p $HOME/.m2
+  mv $LOCAL_SOURCE_DIR/configuration/settings.xml $HOME/.m2
+fi
+
+
+configure_proxy
+configure_mirrors
+
+manage_incremental_build
+if [ -n "${SSO_ADAPTERS_OVERRIDES}" ]; then
+  install_custom_rh_sso_adapters "${SSO_ADAPTERS_OVERRIDES}"
+fi
+
+# If a pom.xml is present, this is a normal build scenario
+# so run maven.
+if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
+  pushd $LOCAL_SOURCE_DIR &> /dev/null
+
+  # Add JVM default options
+  export MAVEN_OPTS="${MAVEN_OPTS:-$(/opt/run-java/java-default-options)}"
+  MAVEN_ARGS=${MAVEN_ARGS--e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga package}
+
+  # Use maven batch mode (CLOUD-579)
+  # Always force IPv4 (CLOUD-188)
+  # Append user-supplied arguments (CLOUD-412)
+  MAVEN_ARGS="$MAVEN_ARGS --batch-mode -Djava.net.preferIPv4Stack=true ${MAVEN_ARGS_APPEND}"
+
+  echo "Found pom.xml... attempting to build with 'mvn ${MAVEN_ARGS}'"
+  echo "Using MAVEN_OPTS '${MAVEN_OPTS}'"
+
+  echo "Using $(mvn --version)"
+
+  # Execute the actual build
+  mvn $MAVEN_ARGS
+
+  ERR=$?
+  if [ $ERR -ne 0 ]; then
+    echo "Aborting due to error code $ERR from Maven build"
+    exit $ERR
+  fi
+
+  # Expand each ARTIFACT_DIR entry to absolute path by prefixing it with $LOCAL_SOURCE_DIR
+  IFS=',' read -a artifact_dir_entries <<< "$ARTIFACT_DIR"
+  artifact_dir_entries=($(printf "$LOCAL_SOURCE_DIR/%s\n" "${artifact_dir_entries[@]}" | tr '\n' ','))
+
+  # Copy built artifacts (if any!) from the target/ directory
+  # (or $ARTIFACT_DIR if specified) to the
+  # $JBOSS_HOME/standalone/deployments/ directory for later deployment
+  # Use artifact directories in absolute path form when copying artifacts
+  copy_artifacts "${artifact_dir_entries[@]}" war ear rar jar
+
+  # optionally clear the local maven repository after the build
+  clear_maven_repository
+
+  popd &> /dev/null
+else
+  copy_artifacts "$LOCAL_SOURCE_DIR" war ear rar jar
+fi
+
+# copy app data, if specified
+if [ -n "$APP_DATADIR" ] && [ -d "$LOCAL_SOURCE_DIR/$APP_DATADIR" ]; then
+  echo "Copying app data from ${APP_DATADIR} to ${DATA_DIR}..."
+  rsync -rl --out-format='%n' "$LOCAL_SOURCE_DIR/$APP_DATADIR/" "$DATA_DIR"
+  chmod -R g+rwX $DATA_DIR
+fi
+
+# Copy (probably binary) artifacts from the deployments/
+# directory to the $JBOSS_HOME/standalone/deployments/
+# directory for later deployment
+copy_artifacts "$LOCAL_SOURCE_DIR/deployments" war ear rar jar
+
+if [ -d $LOCAL_SOURCE_DIR/configuration ]; then
+  file_count=$(ls -1 $LOCAL_SOURCE_DIR/configuration | wc -l)
+  if [ $file_count -gt 0 ]; then
+    echo "Copying config files from project..."
+    cp -v $LOCAL_SOURCE_DIR/configuration/* $JBOSS_HOME/standalone/configuration/
+  fi
+fi
+
+if [ -d $LOCAL_SOURCE_DIR/modules ]; then
+  echo "Copying modules from project..."
+  cp -vr $LOCAL_SOURCE_DIR/modules/* $JBOSS_HOME/modules/
+fi
+
+function copy_injected {
+  source_dir=$1
+  target_dir=$2
+
+  if [ -d "$source_dir" ]; then
+    cp -rf ${source_dir}/* $target_dir
+  fi
+}
+
+if [ -n $CUSTOM_INSTALL_DIRECTORIES ]; then
+  IFS=',' read -a install_dir_entries <<< $CUSTOM_INSTALL_DIRECTORIES
+  for install_dir_entry in "${install_dir_entries[@]}"; do
+    for install_dir in $(find ${LOCAL_SOURCE_DIR}/$install_dir_entry -maxdepth 0 2>/dev/null); do
+      chmod -R 755 ${install_dir}
+      if [ -f ${install_dir}/install.sh ]; then
+        ${install_dir}/install.sh ${install_dir}
+      else
+        copy_injected ${install_dir}/modules $JBOSS_HOME/modules
+
+        copy_injected ${install_dir}/configuration $JBOSS_HOME/standalone/configuration
+
+        copy_artifacts ${install_dir}/deployments war ear rar jar
+      fi
+    done
+  done
+fi
+
+chmod -R g+rwX $HOME
+
+# Remove java tmp perf data dir owned by 185
+rm -rf /tmp/hsperfdata_jboss
+
+exit 0

--- a/eap-s2i-install-custom-rh-sso-adapters/s2i/assemble.orig
+++ b/eap-s2i-install-custom-rh-sso-adapters/s2i/assemble.orig
@@ -1,0 +1,320 @@
+#!/bin/bash
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+fi
+
+# common shell routines for s2i scripts
+
+# insert settings for HTTP proxy into settings.xml if supplied as
+# separate variables HTTP_PROXY_HOST, _PORT, _SCHEME, _USERNAME,
+# _PASSWORD, _NONPROXYHOSTS
+function configure_proxy_write() {
+  local settings="${1:-$HOME/.m2/settings.xml}"
+  if [ -n "$HTTP_PROXY_HOST" -a -n "$HTTP_PROXY_PORT" ]; then
+    xml="<proxy>\
+         <id>genproxy</id>\
+         <active>true</active>\
+         <protocol>${HTTP_PROXY_SCHEME:-http}</protocol>\
+         <host>$HTTP_PROXY_HOST</host>\
+         <port>$HTTP_PROXY_PORT</port>"
+    if [ -n "$HTTP_PROXY_USERNAME" -a -n "$HTTP_PROXY_PASSWORD" ]; then
+      xml="$xml\
+         <username>$HTTP_PROXY_USERNAME</username>\
+         <password>$HTTP_PROXY_PASSWORD</password>"
+    fi
+    if [ -n "$HTTP_PROXY_NONPROXYHOSTS" ]; then
+      xml="$xml\
+         <nonProxyHosts>$HTTP_PROXY_NONPROXYHOSTS</nonProxyHosts>"
+    fi
+  xml="$xml\
+       </proxy>"
+    local sub="<!-- ### configured http proxy ### -->"
+    sed -i "s^${sub}^${xml}^" "$settings"
+  fi
+}
+
+# break a supplied url (as would be in HTTP_PROXY) up into constituent bits and
+# export the bits as variables that match our old scheme for configuring proxies
+# $settings - file to edit
+function configure_proxy_url() {
+  local url="$1"
+  local default_scheme="$2"
+  local default_port="$3"
+  if [ -n "$url" ] ; then
+    #[scheme://][user[:password]@]host[:port][/path][?params]
+    eval $(echo "$1" | sed -e "s+^\(\([^:]*\)://\)\?\(\([^:@]*\)\(:\([^@]*\)\)\?@\)\?\([^:/?]*\)\(:\([^/?]*\)\)\?.*$+HTTP_PROXY_SCHEME='\2' HTTP_PROXY_USERNAME='\4' HTTP_PROXY_PASSWORD='\6' HTTP_PROXY_HOST='\7' HTTP_PROXY_PORT='\9'+")
+
+    HTTP_PROXY_SCHEME="${HTTP_PROXY_SCHEME:-$default_scheme}"
+    HTTP_PROXY_PORT="${HTTP_PROXY_PORT:-$default_port}"
+
+    local noProxy="${no_proxy:-${NO_PROXY}}"
+    if [ -n "$noProxy" ]; then
+        noProxy="${noProxy//,/|}"
+        noProxy="${noProxy//|./|*.}"
+        noProxy="${noProxy/#./*.}"
+        HTTP_PROXY_NONPROXYHOSTS="${noProxy}"
+    fi
+  fi
+}
+
+function configure_proxy() {
+  local httpsProxy="${https_proxy:-${HTTPS_PROXY}}"
+  local httpProxy="${http_proxy:-${HTTP_PROXY}}"
+  local settings="$1"
+
+  if [ -n "${httpsProxy}" ] ; then
+    configure_proxy_url "${httpsProxy}" https 443
+  else
+    if [ -n "${httpProxy}" ] ; then
+      configure_proxy_url "${httpProxy}" http 80
+    fi
+  fi
+  configure_proxy_write "${settings}"
+}
+
+function find_env() {
+  local var=${!1}
+  echo "${var:-$2}"
+}
+
+# insert settings for mirrors/repository managers into settings.xml if supplied
+function configure_mirrors() {
+  local settings="${1-$HOME/.m2/settings.xml}"
+  local counter=1
+
+  # Be backwards compatible
+  if [ -n "${MAVEN_MIRROR_URL}" ]; then
+    local mirror_id=$(find_env "MAVEN_MIRROR_ID" "mirror.default")
+    local mirror_of=$(find_env "MAVEN_MIRROR_OF" "external:*")
+
+    configure_mirror "${settings}" "${mirror_id}" "${MAVEN_MIRROR_URL}" "${mirror_of}"
+  fi
+
+  IFS=',' read -a maven_mirror_prefixes <<< ${MAVEN_MIRRORS}
+  for maven_mirror_prefix in ${maven_mirror_prefixes[@]}; do
+    local mirror_id=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_ID" "mirror${counter}")
+    local mirror_url=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_URL")
+    local mirror_of=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_OF" "external:*")
+
+    if [ -z "${mirror_url}" ]; then
+      echo "WARNING: Variable \"${maven_mirror_prefix}_MAVEN_MIRROR_URL\" not set. Skipping maven mirror setup for the prefix \"${maven_mirror_prefix}\"."
+    else
+      configure_mirror "${settings}" "${mirror_id}" "${mirror_url}" "${mirror_of}"
+    fi
+
+    counter=$((counter+1))
+  done
+}
+
+function configure_mirror() {
+  local settings="${1}"
+  local mirror_id="${2}"
+  local mirror_url="${3}"
+  local mirror_of="${4}"
+
+  local xml="<mirror>\n\
+      <id>${mirror_id}</id>\n\
+      <url>${mirror_url}</url>\n\
+      <mirrorOf>${mirror_of}</mirrorOf>\n\
+    </mirror>\n\
+    <!-- ### configured mirrors ### -->"
+
+  sed -i "s|<!-- ### configured mirrors ### -->|$xml|" "${settings}"
+
+}
+
+# copy all artifacts of types, specified as the second up to n-th
+# argument of the routine into the $DEPLOY_DIR directory
+# Requires: source directory expressed in the form of absolute path!
+function copy_artifacts() {
+  dir=$1
+  types=
+  shift
+  while [ $# -gt 0 ]; do
+    types="$types;$1"
+    shift
+  done
+  
+  for d in $(echo $dir | tr "," "\n")
+  do
+    shift
+    local regex="^\/"
+    if [[ ! "$d" =~ $regex ]]; then
+      echo "$FUNCNAME: Absolute path required for source directory \"$d\"!"
+      exit 1
+    fi
+    for t in $(echo $types | tr ";" "\n")
+    do
+      echo "Copying all $t artifacts from $d directory into $DEPLOY_DIR for later deployment..."
+      cp -rfv $d/*.$t $DEPLOY_DIR 2> /dev/null
+    done
+  done
+}
+
+# handle incremental builds. If we have been passed build artifacts, untar
+# them over the supplied source.
+manage_incremental_build() {
+    if [ -d /tmp/artifacts ]; then
+        echo "Expanding artifacts from incremental build..."
+        ( cd /tmp/artifacts && tar cf - . ) | ( cd ${HOME} && tar xvf - )
+        rm -rf /tmp/artifacts
+    fi
+}
+
+# s2i 'save-artifacts' routine
+s2i_save_build_artifacts() {
+    cd ${HOME}
+    tar cf - .m2
+}
+
+# optionally clear the local maven repository after the build
+clear_maven_repository() {
+    mcr=$(echo "${MAVEN_CLEAR_REPO}" | tr [:upper:] [:lower:])
+    if [ "${mcr}" = "true" ]; then
+        rm -rf ${HOME}/.m2/repository/*
+    fi
+}
+
+# set local repository path for maven to the provided path
+function set_local_repo_path() {
+    local settings="${1}"
+    local local_path="${2}"
+    local xml="\n\
+    <localRepository>${local_path}</localRepository>"
+    sed -i "s|<!-- ### configured local repository ### -->|${xml}|" "${settings}"    
+}
+source /opt/rh/rh-maven35/enable
+
+LOCAL_SOURCE_DIR=/tmp/src
+
+# Resulting WAR files will be deployed to /opt/eap/standalone/deployments
+DEPLOY_DIR=$JBOSS_HOME/standalone/deployments
+
+# JBoss AS data dir. Can be overridden.
+DATA_DIR=${DATA_DIR:-$JBOSS_HOME/standalone/data}
+
+# App data dir. Can be overridden.
+APP_DATADIR=${APP_DATADIR:-data}
+
+# the subdirectory within LOCAL_SOURCE_DIR from where we should copy build
+# artifacts (*.war, *.jar)
+ARTIFACT_DIR=${ARTIFACT_DIR:-target}
+
+if [ -f $LOCAL_SOURCE_DIR/configuration/settings.xml ]; then
+  echo "Copying maven config file from project..."
+  mkdir -p $HOME/.m2
+  mv $LOCAL_SOURCE_DIR/configuration/settings.xml $HOME/.m2
+fi
+
+
+configure_proxy
+configure_mirrors
+
+manage_incremental_build
+
+# If a pom.xml is present, this is a normal build scenario
+# so run maven.
+if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
+  pushd $LOCAL_SOURCE_DIR &> /dev/null
+
+  # Add JVM default options
+  export MAVEN_OPTS="${MAVEN_OPTS:-$(/opt/run-java/java-default-options)}"
+  MAVEN_ARGS=${MAVEN_ARGS--e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga package}
+
+  # Use maven batch mode (CLOUD-579)
+  # Always force IPv4 (CLOUD-188)
+  # Append user-supplied arguments (CLOUD-412)
+  MAVEN_ARGS="$MAVEN_ARGS --batch-mode -Djava.net.preferIPv4Stack=true ${MAVEN_ARGS_APPEND}"
+
+  echo "Found pom.xml... attempting to build with 'mvn ${MAVEN_ARGS}'"
+  echo "Using MAVEN_OPTS '${MAVEN_OPTS}'"
+
+  echo "Using $(mvn --version)"
+
+  # Execute the actual build
+  mvn $MAVEN_ARGS
+
+  ERR=$?
+  if [ $ERR -ne 0 ]; then
+    echo "Aborting due to error code $ERR from Maven build"
+    exit $ERR
+  fi
+
+  # Expand each ARTIFACT_DIR entry to absolute path by prefixing it with $LOCAL_SOURCE_DIR
+  IFS=',' read -a artifact_dir_entries <<< "$ARTIFACT_DIR"
+  artifact_dir_entries=($(printf "$LOCAL_SOURCE_DIR/%s\n" "${artifact_dir_entries[@]}" | tr '\n' ','))
+
+  # Copy built artifacts (if any!) from the target/ directory
+  # (or $ARTIFACT_DIR if specified) to the
+  # $JBOSS_HOME/standalone/deployments/ directory for later deployment
+  # Use artifact directories in absolute path form when copying artifacts
+  copy_artifacts "${artifact_dir_entries[@]}" war ear rar jar
+
+  # optionally clear the local maven repository after the build
+  clear_maven_repository
+
+  popd &> /dev/null
+else
+  copy_artifacts "$LOCAL_SOURCE_DIR" war ear rar jar
+fi
+
+# copy app data, if specified
+if [ -n "$APP_DATADIR" ] && [ -d "$LOCAL_SOURCE_DIR/$APP_DATADIR" ]; then
+  echo "Copying app data from ${APP_DATADIR} to ${DATA_DIR}..."
+  rsync -rl --out-format='%n' "$LOCAL_SOURCE_DIR/$APP_DATADIR/" "$DATA_DIR"
+  chmod -R g+rwX $DATA_DIR
+fi
+
+# Copy (probably binary) artifacts from the deployments/
+# directory to the $JBOSS_HOME/standalone/deployments/
+# directory for later deployment
+copy_artifacts "$LOCAL_SOURCE_DIR/deployments" war ear rar jar
+
+if [ -d $LOCAL_SOURCE_DIR/configuration ]; then
+  file_count=$(ls -1 $LOCAL_SOURCE_DIR/configuration | wc -l)
+  if [ $file_count -gt 0 ]; then
+    echo "Copying config files from project..."
+    cp -v $LOCAL_SOURCE_DIR/configuration/* $JBOSS_HOME/standalone/configuration/
+  fi
+fi
+
+if [ -d $LOCAL_SOURCE_DIR/modules ]; then
+  echo "Copying modules from project..."
+  cp -vr $LOCAL_SOURCE_DIR/modules/* $JBOSS_HOME/modules/
+fi
+
+function copy_injected {
+  source_dir=$1
+  target_dir=$2
+
+  if [ -d "$source_dir" ]; then
+    cp -rf ${source_dir}/* $target_dir
+  fi
+}
+
+if [ -n $CUSTOM_INSTALL_DIRECTORIES ]; then
+  IFS=',' read -a install_dir_entries <<< $CUSTOM_INSTALL_DIRECTORIES
+  for install_dir_entry in "${install_dir_entries[@]}"; do
+    for install_dir in $(find ${LOCAL_SOURCE_DIR}/$install_dir_entry -maxdepth 0 2>/dev/null); do
+      chmod -R 755 ${install_dir}
+      if [ -f ${install_dir}/install.sh ]; then
+        ${install_dir}/install.sh ${install_dir}
+      else
+        copy_injected ${install_dir}/modules $JBOSS_HOME/modules
+
+        copy_injected ${install_dir}/configuration $JBOSS_HOME/standalone/configuration
+
+        copy_artifacts ${install_dir}/deployments war ear rar jar
+      fi
+    done
+  done
+fi
+
+chmod -R g+rwX $HOME
+
+# Remove java tmp perf data dir owned by 185
+rm -rf /tmp/hsperfdata_jboss
+
+exit 0

--- a/eap-s2i-install-custom-rh-sso-adapters/s2i/assemble.orig.unexpanded
+++ b/eap-s2i-install-custom-rh-sso-adapters/s2i/assemble.orig.unexpanded
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+fi
+
+. $(dirname $0)/common.sh
+source /usr/local/s2i/scl-enable-maven
+
+LOCAL_SOURCE_DIR=/tmp/src
+
+# Resulting WAR files will be deployed to /opt/eap/standalone/deployments
+DEPLOY_DIR=$JBOSS_HOME/standalone/deployments
+
+# JBoss AS data dir. Can be overridden.
+DATA_DIR=${DATA_DIR:-$JBOSS_HOME/standalone/data}
+
+# App data dir. Can be overridden.
+APP_DATADIR=${APP_DATADIR:-data}
+
+# the subdirectory within LOCAL_SOURCE_DIR from where we should copy build
+# artifacts (*.war, *.jar)
+ARTIFACT_DIR=${ARTIFACT_DIR:-target}
+
+if [ -f $LOCAL_SOURCE_DIR/configuration/settings.xml ]; then
+  echo "Copying maven config file from project..."
+  mkdir -p $HOME/.m2
+  mv $LOCAL_SOURCE_DIR/configuration/settings.xml $HOME/.m2
+fi
+
+
+configure_proxy
+configure_mirrors
+
+manage_incremental_build
+
+# If a pom.xml is present, this is a normal build scenario
+# so run maven.
+if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
+  pushd $LOCAL_SOURCE_DIR &> /dev/null
+
+  # Add JVM default options
+  export MAVEN_OPTS="${MAVEN_OPTS:-$(/opt/run-java/java-default-options)}"
+  MAVEN_ARGS=${MAVEN_ARGS--e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga package}
+
+  # Use maven batch mode (CLOUD-579)
+  # Always force IPv4 (CLOUD-188)
+  # Append user-supplied arguments (CLOUD-412)
+  MAVEN_ARGS="$MAVEN_ARGS --batch-mode -Djava.net.preferIPv4Stack=true ${MAVEN_ARGS_APPEND}"
+
+  echo "Found pom.xml... attempting to build with 'mvn ${MAVEN_ARGS}'"
+  echo "Using MAVEN_OPTS '${MAVEN_OPTS}'"
+
+  echo "Using $(mvn --version)"
+
+  # Execute the actual build
+  mvn $MAVEN_ARGS
+
+  ERR=$?
+  if [ $ERR -ne 0 ]; then
+    echo "Aborting due to error code $ERR from Maven build"
+    exit $ERR
+  fi
+
+  # Expand each ARTIFACT_DIR entry to absolute path by prefixing it with $LOCAL_SOURCE_DIR
+  IFS=',' read -a artifact_dir_entries <<< "$ARTIFACT_DIR"
+  artifact_dir_entries=($(printf "$LOCAL_SOURCE_DIR/%s\n" "${artifact_dir_entries[@]}" | tr '\n' ','))
+
+  # Copy built artifacts (if any!) from the target/ directory
+  # (or $ARTIFACT_DIR if specified) to the
+  # $JBOSS_HOME/standalone/deployments/ directory for later deployment
+  # Use artifact directories in absolute path form when copying artifacts
+  copy_artifacts "${artifact_dir_entries[@]}" war ear rar jar
+
+  # optionally clear the local maven repository after the build
+  clear_maven_repository
+
+  popd &> /dev/null
+else
+  copy_artifacts "$LOCAL_SOURCE_DIR" war ear rar jar
+fi
+
+# copy app data, if specified
+if [ -n "$APP_DATADIR" ] && [ -d "$LOCAL_SOURCE_DIR/$APP_DATADIR" ]; then
+  echo "Copying app data from ${APP_DATADIR} to ${DATA_DIR}..."
+  rsync -rl --out-format='%n' "$LOCAL_SOURCE_DIR/$APP_DATADIR/" "$DATA_DIR"
+  chmod -R g+rwX $DATA_DIR
+fi
+
+# Copy (probably binary) artifacts from the deployments/
+# directory to the $JBOSS_HOME/standalone/deployments/
+# directory for later deployment
+copy_artifacts "$LOCAL_SOURCE_DIR/deployments" war ear rar jar
+
+if [ -d $LOCAL_SOURCE_DIR/configuration ]; then
+  file_count=$(ls -1 $LOCAL_SOURCE_DIR/configuration | wc -l)
+  if [ $file_count -gt 0 ]; then
+    echo "Copying config files from project..."
+    cp -v $LOCAL_SOURCE_DIR/configuration/* $JBOSS_HOME/standalone/configuration/
+  fi
+fi
+
+if [ -d $LOCAL_SOURCE_DIR/modules ]; then
+  echo "Copying modules from project..."
+  cp -vr $LOCAL_SOURCE_DIR/modules/* $JBOSS_HOME/modules/
+fi
+
+function copy_injected {
+  source_dir=$1
+  target_dir=$2
+
+  if [ -d "$source_dir" ]; then
+    cp -rf ${source_dir}/* $target_dir
+  fi
+}
+
+if [ -n $CUSTOM_INSTALL_DIRECTORIES ]; then
+  IFS=',' read -a install_dir_entries <<< $CUSTOM_INSTALL_DIRECTORIES
+  for install_dir_entry in "${install_dir_entries[@]}"; do
+    for install_dir in $(find ${LOCAL_SOURCE_DIR}/$install_dir_entry -maxdepth 0 2>/dev/null); do
+      chmod -R 755 ${install_dir}
+      if [ -f ${install_dir}/install.sh ]; then
+        ${install_dir}/install.sh ${install_dir}
+      else
+        copy_injected ${install_dir}/modules $JBOSS_HOME/modules
+
+        copy_injected ${install_dir}/configuration $JBOSS_HOME/standalone/configuration
+
+        copy_artifacts ${install_dir}/deployments war ear rar jar
+      fi
+    done
+  done
+fi
+
+chmod -R g+rwX $HOME
+
+# Remove java tmp perf data dir owned by 185
+rm -rf /tmp/hsperfdata_jboss
+
+exit 0

--- a/eap-s2i-install-custom-rh-sso-adapters/s2i/common.sh
+++ b/eap-s2i-install-custom-rh-sso-adapters/s2i/common.sh
@@ -1,0 +1,180 @@
+# common shell routines for s2i scripts
+
+# insert settings for HTTP proxy into settings.xml if supplied as
+# separate variables HTTP_PROXY_HOST, _PORT, _SCHEME, _USERNAME,
+# _PASSWORD, _NONPROXYHOSTS
+function configure_proxy_write() {
+  local settings="${1:-$HOME/.m2/settings.xml}"
+  if [ -n "$HTTP_PROXY_HOST" -a -n "$HTTP_PROXY_PORT" ]; then
+    xml="<proxy>\
+         <id>genproxy</id>\
+         <active>true</active>\
+         <protocol>${HTTP_PROXY_SCHEME:-http}</protocol>\
+         <host>$HTTP_PROXY_HOST</host>\
+         <port>$HTTP_PROXY_PORT</port>"
+    if [ -n "$HTTP_PROXY_USERNAME" -a -n "$HTTP_PROXY_PASSWORD" ]; then
+      xml="$xml\
+         <username>$HTTP_PROXY_USERNAME</username>\
+         <password>$HTTP_PROXY_PASSWORD</password>"
+    fi
+    if [ -n "$HTTP_PROXY_NONPROXYHOSTS" ]; then
+      xml="$xml\
+         <nonProxyHosts>$HTTP_PROXY_NONPROXYHOSTS</nonProxyHosts>"
+    fi
+  xml="$xml\
+       </proxy>"
+    local sub="<!-- ### configured http proxy ### -->"
+    sed -i "s^${sub}^${xml}^" "$settings"
+  fi
+}
+
+# break a supplied url (as would be in HTTP_PROXY) up into constituent bits and
+# export the bits as variables that match our old scheme for configuring proxies
+# $settings - file to edit
+function configure_proxy_url() {
+  local url="$1"
+  local default_scheme="$2"
+  local default_port="$3"
+  if [ -n "$url" ] ; then
+    #[scheme://][user[:password]@]host[:port][/path][?params]
+    eval $(echo "$1" | sed -e "s+^\(\([^:]*\)://\)\?\(\([^:@]*\)\(:\([^@]*\)\)\?@\)\?\([^:/?]*\)\(:\([^/?]*\)\)\?.*$+HTTP_PROXY_SCHEME='\2' HTTP_PROXY_USERNAME='\4' HTTP_PROXY_PASSWORD='\6' HTTP_PROXY_HOST='\7' HTTP_PROXY_PORT='\9'+")
+
+    HTTP_PROXY_SCHEME="${HTTP_PROXY_SCHEME:-$default_scheme}"
+    HTTP_PROXY_PORT="${HTTP_PROXY_PORT:-$default_port}"
+
+    local noProxy="${no_proxy:-${NO_PROXY}}"
+    if [ -n "$noProxy" ]; then
+        noProxy="${noProxy//,/|}"
+        noProxy="${noProxy//|./|*.}"
+        noProxy="${noProxy/#./*.}"
+        HTTP_PROXY_NONPROXYHOSTS="${noProxy}"
+    fi
+  fi
+}
+
+function configure_proxy() {
+  local httpsProxy="${https_proxy:-${HTTPS_PROXY}}"
+  local httpProxy="${http_proxy:-${HTTP_PROXY}}"
+  local settings="$1"
+
+  if [ -n "${httpsProxy}" ] ; then
+    configure_proxy_url "${httpsProxy}" https 443
+  else
+    if [ -n "${httpProxy}" ] ; then
+      configure_proxy_url "${httpProxy}" http 80
+    fi
+  fi
+  configure_proxy_write "${settings}"
+}
+
+function find_env() {
+  local var=${!1}
+  echo "${var:-$2}"
+}
+
+# insert settings for mirrors/repository managers into settings.xml if supplied
+function configure_mirrors() {
+  local settings="${1-$HOME/.m2/settings.xml}"
+  local counter=1
+
+  # Be backwards compatible
+  if [ -n "${MAVEN_MIRROR_URL}" ]; then
+    local mirror_id=$(find_env "MAVEN_MIRROR_ID" "mirror.default")
+    local mirror_of=$(find_env "MAVEN_MIRROR_OF" "external:*")
+
+    configure_mirror "${settings}" "${mirror_id}" "${MAVEN_MIRROR_URL}" "${mirror_of}"
+  fi
+
+  IFS=',' read -a maven_mirror_prefixes <<< ${MAVEN_MIRRORS}
+  for maven_mirror_prefix in ${maven_mirror_prefixes[@]}; do
+    local mirror_id=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_ID" "mirror${counter}")
+    local mirror_url=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_URL")
+    local mirror_of=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_OF" "external:*")
+
+    if [ -z "${mirror_url}" ]; then
+      echo "WARNING: Variable \"${maven_mirror_prefix}_MAVEN_MIRROR_URL\" not set. Skipping maven mirror setup for the prefix \"${maven_mirror_prefix}\"."
+    else
+      configure_mirror "${settings}" "${mirror_id}" "${mirror_url}" "${mirror_of}"
+    fi
+
+    counter=$((counter+1))
+  done
+}
+
+function configure_mirror() {
+  local settings="${1}"
+  local mirror_id="${2}"
+  local mirror_url="${3}"
+  local mirror_of="${4}"
+
+  local xml="<mirror>\n\
+      <id>${mirror_id}</id>\n\
+      <url>${mirror_url}</url>\n\
+      <mirrorOf>${mirror_of}</mirrorOf>\n\
+    </mirror>\n\
+    <!-- ### configured mirrors ### -->"
+
+  sed -i "s|<!-- ### configured mirrors ### -->|$xml|" "${settings}"
+
+}
+
+# copy all artifacts of types, specified as the second up to n-th
+# argument of the routine into the $DEPLOY_DIR directory
+# Requires: source directory expressed in the form of absolute path!
+function copy_artifacts() {
+  dir=$1
+  types=
+  shift
+  while [ $# -gt 0 ]; do
+    types="$types;$1"
+    shift
+  done
+  
+  for d in $(echo $dir | tr "," "\n")
+  do
+    shift
+    local regex="^\/"
+    if [[ ! "$d" =~ $regex ]]; then
+      echo "$FUNCNAME: Absolute path required for source directory \"$d\"!"
+      exit 1
+    fi
+    for t in $(echo $types | tr ";" "\n")
+    do
+      echo "Copying all $t artifacts from $d directory into $DEPLOY_DIR for later deployment..."
+      cp -rfv $d/*.$t $DEPLOY_DIR 2> /dev/null
+    done
+  done
+}
+
+# handle incremental builds. If we have been passed build artifacts, untar
+# them over the supplied source.
+manage_incremental_build() {
+    if [ -d /tmp/artifacts ]; then
+        echo "Expanding artifacts from incremental build..."
+        ( cd /tmp/artifacts && tar cf - . ) | ( cd ${HOME} && tar xvf - )
+        rm -rf /tmp/artifacts
+    fi
+}
+
+# s2i 'save-artifacts' routine
+s2i_save_build_artifacts() {
+    cd ${HOME}
+    tar cf - .m2
+}
+
+# optionally clear the local maven repository after the build
+clear_maven_repository() {
+    mcr=$(echo "${MAVEN_CLEAR_REPO}" | tr [:upper:] [:lower:])
+    if [ "${mcr}" = "true" ]; then
+        rm -rf ${HOME}/.m2/repository/*
+    fi
+}
+
+# set local repository path for maven to the provided path
+function set_local_repo_path() {
+    local settings="${1}"
+    local local_path="${2}"
+    local xml="\n\
+    <localRepository>${local_path}</localRepository>"
+    sed -i "s|<!-- ### configured local repository ### -->|${xml}|" "${settings}"    
+}

--- a/eap-s2i-install-custom-rh-sso-adapters/s2i/run
+++ b/eap-s2i-install-custom-rh-sso-adapters/s2i/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec $JBOSS_HOME/bin/openshift-launch.sh

--- a/eap-s2i-install-custom-rh-sso-adapters/s2i/save-artifacts
+++ b/eap-s2i-install-custom-rh-sso-adapters/s2i/save-artifacts
@@ -1,0 +1,184 @@
+#!/bin/sh
+set -ue
+# common shell routines for s2i scripts
+
+# insert settings for HTTP proxy into settings.xml if supplied as
+# separate variables HTTP_PROXY_HOST, _PORT, _SCHEME, _USERNAME,
+# _PASSWORD, _NONPROXYHOSTS
+function configure_proxy_write() {
+  local settings="${1:-$HOME/.m2/settings.xml}"
+  if [ -n "$HTTP_PROXY_HOST" -a -n "$HTTP_PROXY_PORT" ]; then
+    xml="<proxy>\
+         <id>genproxy</id>\
+         <active>true</active>\
+         <protocol>${HTTP_PROXY_SCHEME:-http}</protocol>\
+         <host>$HTTP_PROXY_HOST</host>\
+         <port>$HTTP_PROXY_PORT</port>"
+    if [ -n "$HTTP_PROXY_USERNAME" -a -n "$HTTP_PROXY_PASSWORD" ]; then
+      xml="$xml\
+         <username>$HTTP_PROXY_USERNAME</username>\
+         <password>$HTTP_PROXY_PASSWORD</password>"
+    fi
+    if [ -n "$HTTP_PROXY_NONPROXYHOSTS" ]; then
+      xml="$xml\
+         <nonProxyHosts>$HTTP_PROXY_NONPROXYHOSTS</nonProxyHosts>"
+    fi
+  xml="$xml\
+       </proxy>"
+    local sub="<!-- ### configured http proxy ### -->"
+    sed -i "s^${sub}^${xml}^" "$settings"
+  fi
+}
+
+# break a supplied url (as would be in HTTP_PROXY) up into constituent bits and
+# export the bits as variables that match our old scheme for configuring proxies
+# $settings - file to edit
+function configure_proxy_url() {
+  local url="$1"
+  local default_scheme="$2"
+  local default_port="$3"
+  if [ -n "$url" ] ; then
+    #[scheme://][user[:password]@]host[:port][/path][?params]
+    eval $(echo "$1" | sed -e "s+^\(\([^:]*\)://\)\?\(\([^:@]*\)\(:\([^@]*\)\)\?@\)\?\([^:/?]*\)\(:\([^/?]*\)\)\?.*$+HTTP_PROXY_SCHEME='\2' HTTP_PROXY_USERNAME='\4' HTTP_PROXY_PASSWORD='\6' HTTP_PROXY_HOST='\7' HTTP_PROXY_PORT='\9'+")
+
+    HTTP_PROXY_SCHEME="${HTTP_PROXY_SCHEME:-$default_scheme}"
+    HTTP_PROXY_PORT="${HTTP_PROXY_PORT:-$default_port}"
+
+    local noProxy="${no_proxy:-${NO_PROXY}}"
+    if [ -n "$noProxy" ]; then
+        noProxy="${noProxy//,/|}"
+        noProxy="${noProxy//|./|*.}"
+        noProxy="${noProxy/#./*.}"
+        HTTP_PROXY_NONPROXYHOSTS="${noProxy}"
+    fi
+  fi
+}
+
+function configure_proxy() {
+  local httpsProxy="${https_proxy:-${HTTPS_PROXY}}"
+  local httpProxy="${http_proxy:-${HTTP_PROXY}}"
+  local settings="$1"
+
+  if [ -n "${httpsProxy}" ] ; then
+    configure_proxy_url "${httpsProxy}" https 443
+  else
+    if [ -n "${httpProxy}" ] ; then
+      configure_proxy_url "${httpProxy}" http 80
+    fi
+  fi
+  configure_proxy_write "${settings}"
+}
+
+function find_env() {
+  local var=${!1}
+  echo "${var:-$2}"
+}
+
+# insert settings for mirrors/repository managers into settings.xml if supplied
+function configure_mirrors() {
+  local settings="${1-$HOME/.m2/settings.xml}"
+  local counter=1
+
+  # Be backwards compatible
+  if [ -n "${MAVEN_MIRROR_URL}" ]; then
+    local mirror_id=$(find_env "MAVEN_MIRROR_ID" "mirror.default")
+    local mirror_of=$(find_env "MAVEN_MIRROR_OF" "external:*")
+
+    configure_mirror "${settings}" "${mirror_id}" "${MAVEN_MIRROR_URL}" "${mirror_of}"
+  fi
+
+  IFS=',' read -a maven_mirror_prefixes <<< ${MAVEN_MIRRORS}
+  for maven_mirror_prefix in ${maven_mirror_prefixes[@]}; do
+    local mirror_id=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_ID" "mirror${counter}")
+    local mirror_url=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_URL")
+    local mirror_of=$(find_env "${maven_mirror_prefix}_MAVEN_MIRROR_OF" "external:*")
+
+    if [ -z "${mirror_url}" ]; then
+      echo "WARNING: Variable \"${maven_mirror_prefix}_MAVEN_MIRROR_URL\" not set. Skipping maven mirror setup for the prefix \"${maven_mirror_prefix}\"."
+    else
+      configure_mirror "${settings}" "${mirror_id}" "${mirror_url}" "${mirror_of}"
+    fi
+
+    counter=$((counter+1))
+  done
+}
+
+function configure_mirror() {
+  local settings="${1}"
+  local mirror_id="${2}"
+  local mirror_url="${3}"
+  local mirror_of="${4}"
+
+  local xml="<mirror>\n\
+      <id>${mirror_id}</id>\n\
+      <url>${mirror_url}</url>\n\
+      <mirrorOf>${mirror_of}</mirrorOf>\n\
+    </mirror>\n\
+    <!-- ### configured mirrors ### -->"
+
+  sed -i "s|<!-- ### configured mirrors ### -->|$xml|" "${settings}"
+
+}
+
+# copy all artifacts of types, specified as the second up to n-th
+# argument of the routine into the $DEPLOY_DIR directory
+# Requires: source directory expressed in the form of absolute path!
+function copy_artifacts() {
+  dir=$1
+  types=
+  shift
+  while [ $# -gt 0 ]; do
+    types="$types;$1"
+    shift
+  done
+  
+  for d in $(echo $dir | tr "," "\n")
+  do
+    shift
+    local regex="^\/"
+    if [[ ! "$d" =~ $regex ]]; then
+      echo "$FUNCNAME: Absolute path required for source directory \"$d\"!"
+      exit 1
+    fi
+    for t in $(echo $types | tr ";" "\n")
+    do
+      echo "Copying all $t artifacts from $d directory into $DEPLOY_DIR for later deployment..."
+      cp -rfv $d/*.$t $DEPLOY_DIR 2> /dev/null
+    done
+  done
+}
+
+# handle incremental builds. If we have been passed build artifacts, untar
+# them over the supplied source.
+manage_incremental_build() {
+    if [ -d /tmp/artifacts ]; then
+        echo "Expanding artifacts from incremental build..."
+        ( cd /tmp/artifacts && tar cf - . ) | ( cd ${HOME} && tar xvf - )
+        rm -rf /tmp/artifacts
+    fi
+}
+
+# s2i 'save-artifacts' routine
+s2i_save_build_artifacts() {
+    cd ${HOME}
+    tar cf - .m2
+}
+
+# optionally clear the local maven repository after the build
+clear_maven_repository() {
+    mcr=$(echo "${MAVEN_CLEAR_REPO}" | tr [:upper:] [:lower:])
+    if [ "${mcr}" = "true" ]; then
+        rm -rf ${HOME}/.m2/repository/*
+    fi
+}
+
+# set local repository path for maven to the provided path
+function set_local_repo_path() {
+    local settings="${1}"
+    local local_path="${2}"
+    local xml="\n\
+    <localRepository>${local_path}</localRepository>"
+    sed -i "s|<!-- ### configured local repository ### -->|${xml}|" "${settings}"    
+}
+
+s2i_save_build_artifacts

--- a/eap-s2i-install-custom-rh-sso-adapters/s2i/scl-enable-maven
+++ b/eap-s2i-install-custom-rh-sso-adapters/s2i/scl-enable-maven
@@ -1,0 +1,1 @@
+source /opt/rh/rh-maven35/enable


### PR DESCRIPTION

The change consists of the following:
* First import the default form of ```assemble```, ```run```, and ```save-artifacts``` S2I builder image scripts, as shipped with EAP images,
* Modify the ```assemble``` script with the expanded (code directly included) form of ```common.sh``` and ```scl-enable-maven``` scripts,
* Then modify the ```assemble``` script to add new ```install_custom_rh_sso_adapters()``` routine and new ```SSO_ADAPTERS_OVERRIDES``` environment variable,
* Define the logging routines from the logging module in the ```assemble``` script (so the messages / warnings have uniform format),
* Finally, describe how to use this change in README.md for both cases:
  - Applying the customized S2I scripts just for one specific buildConfig, or
  - Modifying the default form of eap64-sso-s2i and eap71-sso-s2i templates, so the RH-SSO adapters would be overridden by each provisioning of a EAP application pod from these modified templates

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

```
P.S.: (Note mainly for myself) Once reviewed, and accepted, the provided S2I scripts
URL in the README.md file need to updated to match the final location.
```